### PR TITLE
Fixes Issue #23

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -84,7 +84,7 @@ pub fn start(mut conf: Config) {
                 }
                 debug!("{}={}", clone.key, result);
                 output_folder.push(clone.key);
-                match OpenOptions::new().append(true).create(true).open(&output_folder)
+                match OpenOptions::new().write(true).append(true).create(true).open(&output_folder)
                     .and_then(|mut file| {
                         file.write(&format!("{} {}", cur_time, &result).as_bytes()[..])
                     })


### PR DESCRIPTION
Missing 'write(true)' in OpenOptions lead to bad file descriptor.