### PR TITLE
Fix Bug: unreachable expression warning

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -217,11 +217,12 @@ impl PartialOrd for Item {
 impl Ord for Item {
     fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
         if self.next_time < other.next_time {
-            return ::std::cmp::Ordering::Greater
+            ::std::cmp::Ordering::Greater
+        } else if self.next_time == other.next_time {
+            ::std::cmp::Ordering::Equal
         } else {
-            return ::std::cmp::Ordering::Less
+            ::std::cmp::Ordering::Less
         }
-        ::std::cmp::Ordering::Equal
     }
 }
 


### PR DESCRIPTION
The `impl Ord` did not consider when both `next_time` fields have the
same value. This might result in unwanted behaviour in some edge cases.

Signed-off-by: Matthias Beyer <mail@beyermatthias.de>